### PR TITLE
feat: add git watcher for local repo activity monitoring

### DIFF
--- a/demo/auphanim.json
+++ b/demo/auphanim.json
@@ -49,6 +49,15 @@
       "paths": ["/tmp/auphanim-demo/app.log"],
       "error_patterns": ["ERROR", "FATAL", "PANIC"],
       "max_events": 100
+    },
+    {
+      "name": "My Repos",
+      "type": "git",
+      "path": "~/Projects",
+      "poll_interval_s": 60,
+      "alert_files_changed": 50,
+      "alert_branch_age_days": 14,
+      "max_events": 100
     }
   ]
 }

--- a/demo/auphanim.json
+++ b/demo/auphanim.json
@@ -53,7 +53,7 @@
     {
       "name": "My Repos",
       "type": "git",
-      "path": "~/Projects",
+      "path": "/path/to/your/repos",
       "poll_interval_s": 60,
       "alert_files_changed": 50,
       "alert_branch_age_days": 14,

--- a/internal/watcher/git/watcher.go
+++ b/internal/watcher/git/watcher.go
@@ -1,0 +1,426 @@
+// Package git watches one or more local git repositories for activity.
+//
+// Point "path" at a single git repo OR at a parent directory that contains
+// multiple repos (one level deep). The watcher polls on poll_interval_s
+// (default 60 s) by running a `git fetch` and then inspecting branch state.
+//
+// Events emitted:
+//   - Startup: repos discovered and watched
+//   - New commits pushed to the current branch by someone else
+//   - New commits landed on main/master that you may need to rebase onto
+//   - Warning when files-changed count in the branch exceeds alert_files_changed
+//   - Warning when the branch has lived longer than alert_branch_age_days
+package git
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"auphanim/internal/events"
+	"auphanim/internal/watcher"
+)
+
+const (
+	defaultPollInterval    = 60
+	defaultAlertFiles      = 50
+	defaultAlertBranchDays = 14
+)
+
+func init() {
+	watcher.Register("git", func(name string, raw json.RawMessage) (watcher.Watcher, error) {
+		cfg := Config{
+			PollIntervalS:      defaultPollInterval,
+			AlertFilesChanged:  defaultAlertFiles,
+			AlertBranchAgeDays: defaultAlertBranchDays,
+			MaxEvents:          100,
+		}
+		if len(raw) > 0 {
+			if err := json.Unmarshal(raw, &cfg); err != nil {
+				return nil, err
+			}
+		}
+		if cfg.PollIntervalS <= 0 {
+			cfg.PollIntervalS = defaultPollInterval
+		}
+		if cfg.AlertFilesChanged <= 0 {
+			cfg.AlertFilesChanged = defaultAlertFiles
+		}
+		if cfg.AlertBranchAgeDays <= 0 {
+			cfg.AlertBranchAgeDays = defaultAlertBranchDays
+		}
+		if cfg.Path == "" {
+			return nil, fmt.Errorf("git watcher %q: path is required", name)
+		}
+		return &Watcher{
+			name:     name,
+			cfg:      cfg,
+			eventsCh: make(chan events.WatchEvent, 64),
+			status:   watcher.StatusConnecting,
+		}, nil
+	})
+}
+
+// Config holds git-watcher-specific configuration.
+type Config struct {
+	// Path to a git repo OR a directory whose immediate subdirectories are repos.
+	Path string `json:"path"`
+
+	// How often to poll (run git fetch + inspect). Default: 60 s.
+	PollIntervalS int `json:"poll_interval_s"`
+
+	// Emit a warning when a branch has more than this many files changed vs
+	// main/master. 0 disables the check. Default: 50.
+	AlertFilesChanged int `json:"alert_files_changed"`
+
+	// Emit a warning when a branch is older than this many days. 0 disables
+	// the check. Default: 14.
+	AlertBranchAgeDays int `json:"alert_branch_age_days"`
+
+	MaxEvents int `json:"max_events"`
+}
+
+// repoState tracks per-repo inter-poll state.
+type repoState struct {
+	path            string
+	currentBranch   string
+	lastRemoteHead  string // last seen origin/<currentBranch> SHA
+	lastMainHead    string // last seen origin/<main|master> SHA
+	filesWarnIssued bool   // true once we've fired the files-changed warning
+	ageWarnIssued   bool   // true once we've fired the branch-age warning
+}
+
+// Watcher is the git watcher implementation.
+type Watcher struct {
+	name     string
+	cfg      Config
+	eventsCh chan events.WatchEvent
+	status   watcher.Status
+	mu       sync.RWMutex
+	cancel   context.CancelFunc
+	repos    []*repoState
+}
+
+func (w *Watcher) Name() string                     { return w.name }
+func (w *Watcher) Type() string                     { return "git" }
+func (w *Watcher) Events() <-chan events.WatchEvent { return w.eventsCh }
+
+func (w *Watcher) Status() watcher.Status {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	return w.status
+}
+
+func (w *Watcher) setStatus(s watcher.Status) {
+	w.mu.Lock()
+	w.status = s
+	w.mu.Unlock()
+}
+
+func (w *Watcher) Start(ctx context.Context) error {
+	ctx, w.cancel = context.WithCancel(ctx)
+	go w.run(ctx)
+	return nil
+}
+
+func (w *Watcher) Stop() {
+	if w.cancel != nil {
+		w.cancel()
+	}
+}
+
+func (w *Watcher) emit(t events.EventType, summary string, detail map[string]any) {
+	select {
+	case w.eventsCh <- events.WatchEvent{
+		Timestamp:   time.Now(),
+		WatcherName: w.name,
+		WatcherType: "git",
+		Type:        t,
+		Summary:     summary,
+		Detail:      detail,
+	}:
+	default:
+	}
+}
+
+func (w *Watcher) run(ctx context.Context) {
+	defer close(w.eventsCh)
+	defer w.setStatus(watcher.StatusStopped)
+
+	// Resolve and discover repos.
+	root, err := expandPath(w.cfg.Path)
+	if err != nil {
+		w.setStatus(watcher.StatusError)
+		w.emit(events.EventError, fmt.Sprintf("cannot expand path %q: %v", w.cfg.Path, err), nil)
+		return
+	}
+
+	paths, err := discoverRepos(root)
+	if err != nil {
+		w.setStatus(watcher.StatusError)
+		w.emit(events.EventError, fmt.Sprintf("cannot discover repos in %q: %v", root, err), nil)
+		return
+	}
+	if len(paths) == 0 {
+		w.setStatus(watcher.StatusError)
+		w.emit(events.EventError, fmt.Sprintf("no git repos found in %q", root), nil)
+		return
+	}
+
+	w.repos = make([]*repoState, len(paths))
+	for i, p := range paths {
+		w.repos[i] = &repoState{path: p}
+	}
+
+	// Announce what we found.
+	w.setStatus(watcher.StatusConnected)
+	if len(paths) == 1 {
+		w.emit(events.EventMessage,
+			fmt.Sprintf("watching repo: %s", filepath.Base(paths[0])),
+			map[string]any{"path": paths[0]})
+	} else {
+		names := make([]string, len(paths))
+		for i, p := range paths {
+			names[i] = filepath.Base(p)
+		}
+		w.emit(events.EventMessage,
+			fmt.Sprintf("watching %d repos under %s", len(paths), filepath.Base(root)),
+			map[string]any{"repos": names, "root": root})
+	}
+
+	// Seed state without emitting events (establishes baseline).
+	for _, rs := range w.repos {
+		w.fetchAndSeed(ctx, rs)
+	}
+
+	ticker := time.NewTicker(time.Duration(w.cfg.PollIntervalS) * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			for _, rs := range w.repos {
+				w.poll(ctx, rs)
+			}
+		}
+	}
+}
+
+// fetchAndSeed runs git fetch and records the current remote state as the
+// baseline so the first real poll only reports changes from that point on.
+func (w *Watcher) fetchAndSeed(ctx context.Context, rs *repoState) {
+	gitFetch(ctx, rs.path)
+
+	branch, err := gitOut(ctx, rs.path, "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return
+	}
+	rs.currentBranch = branch
+	rs.lastRemoteHead, _ = gitOut(ctx, rs.path, "rev-parse", "origin/"+branch)
+	if mb := mainBranch(ctx, rs.path); mb != "" {
+		rs.lastMainHead, _ = gitOut(ctx, rs.path, "rev-parse", "origin/"+mb)
+	}
+}
+
+// poll fetches and checks for interesting changes, emitting events as needed.
+func (w *Watcher) poll(ctx context.Context, rs *repoState) {
+	gitFetch(ctx, rs.path)
+
+	repoLabel := filepath.Base(rs.path)
+
+	// ── Current branch ────────────────────────────────────────────────────────
+	branch, err := gitOut(ctx, rs.path, "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return
+	}
+
+	// Branch switch: reset remote tracking for the new branch.
+	if rs.currentBranch != "" && branch != rs.currentBranch {
+		w.emit(events.EventMessage,
+			fmt.Sprintf("[%s] switched branch: %s → %s", repoLabel, rs.currentBranch, branch),
+			map[string]any{"repo": rs.path, "old": rs.currentBranch, "new": branch})
+		rs.currentBranch = branch
+		rs.lastRemoteHead, _ = gitOut(ctx, rs.path, "rev-parse", "origin/"+branch)
+		rs.filesWarnIssued = false
+		rs.ageWarnIssued = false
+	}
+	rs.currentBranch = branch
+
+	// ── Remote pushes to the current branch ───────────────────────────────────
+	remoteHead, _ := gitOut(ctx, rs.path, "rev-parse", "origin/"+branch)
+	if remoteHead != "" && rs.lastRemoteHead != "" && remoteHead != rs.lastRemoteHead {
+		commits, _ := gitLines(ctx, rs.path, "log",
+			rs.lastRemoteHead+".."+remoteHead, "--oneline", "--no-decorate")
+		w.emit(events.EventMessage,
+			fmt.Sprintf("[%s] %d new commit(s) pushed to %s by someone else",
+				repoLabel, len(commits), branch),
+			map[string]any{
+				"repo":    rs.path,
+				"branch":  branch,
+				"commits": commits,
+				"count":   len(commits),
+			})
+	}
+	if remoteHead != "" {
+		rs.lastRemoteHead = remoteHead
+	}
+
+	// ── Activity on main/master ───────────────────────────────────────────────
+	mb := mainBranch(ctx, rs.path)
+	if mb != "" && branch != mb {
+		mainHead, _ := gitOut(ctx, rs.path, "rev-parse", "origin/"+mb)
+		if mainHead != "" && rs.lastMainHead != "" && mainHead != rs.lastMainHead {
+			commits, _ := gitLines(ctx, rs.path, "log",
+				rs.lastMainHead+".."+mainHead, "--oneline", "--no-decorate")
+			w.emit(events.EventMessage,
+				fmt.Sprintf("[%s] %d new commit(s) landed on %s — consider rebasing",
+					repoLabel, len(commits), mb),
+				map[string]any{
+					"repo":           rs.path,
+					"main_branch":    mb,
+					"current_branch": branch,
+					"commits":        commits,
+					"count":          len(commits),
+				})
+		}
+		if mainHead != "" {
+			rs.lastMainHead = mainHead
+		}
+
+		// ── Files-changed threshold ────────────────────────────────────────────
+		if w.cfg.AlertFilesChanged > 0 {
+			files, _ := gitLines(ctx, rs.path, "diff", "--name-only", "origin/"+mb+"...HEAD")
+			n := len(files)
+			if n > w.cfg.AlertFilesChanged && !rs.filesWarnIssued {
+				rs.filesWarnIssued = true
+				w.emit(events.EventError,
+					fmt.Sprintf("[%s] branch %s has %d files changed (threshold %d) — consider splitting the PR",
+						repoLabel, branch, n, w.cfg.AlertFilesChanged),
+					map[string]any{
+						"repo":          rs.path,
+						"branch":        branch,
+						"files_changed": n,
+						"threshold":     w.cfg.AlertFilesChanged,
+						"files":         files,
+					})
+			} else if n <= w.cfg.AlertFilesChanged {
+				rs.filesWarnIssued = false
+			}
+		}
+
+		// ── Branch-age threshold ───────────────────────────────────────────────
+		if w.cfg.AlertBranchAgeDays > 0 {
+			mergeBase, err := gitOut(ctx, rs.path, "merge-base", "HEAD", "origin/"+mb)
+			if err == nil && mergeBase != "" {
+				tsStr, err := gitOut(ctx, rs.path, "log", "--format=%ct", "-1", mergeBase)
+				if err == nil && tsStr != "" {
+					if ts, err := strconv.ParseInt(tsStr, 10, 64); err == nil {
+						ageDays := int(time.Since(time.Unix(ts, 0)).Hours() / 24)
+						if ageDays > w.cfg.AlertBranchAgeDays && !rs.ageWarnIssued {
+							rs.ageWarnIssued = true
+							w.emit(events.EventError,
+								fmt.Sprintf("[%s] branch %s is %d days old (threshold %d days) — time to merge or rebase",
+									repoLabel, branch, ageDays, w.cfg.AlertBranchAgeDays),
+								map[string]any{
+									"repo":           rs.path,
+									"branch":         branch,
+									"age_days":       ageDays,
+									"threshold_days": w.cfg.AlertBranchAgeDays,
+								})
+						} else if ageDays <= w.cfg.AlertBranchAgeDays {
+							rs.ageWarnIssued = false
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+// expandPath resolves ~ and cleans the path.
+func expandPath(p string) (string, error) {
+	if strings.HasPrefix(p, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		p = filepath.Join(home, p[2:])
+	}
+	return filepath.Clean(p), nil
+}
+
+// discoverRepos returns the repo paths to watch:
+//   - If root itself is a git repo, returns [root].
+//   - Otherwise scans one level deep for subdirectories that are git repos.
+func discoverRepos(root string) ([]string, error) {
+	if isGitRepo(root) {
+		return []string{root}, nil
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read %s: %w", root, err)
+	}
+	var repos []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		p := filepath.Join(root, e.Name())
+		if isGitRepo(p) {
+			repos = append(repos, p)
+		}
+	}
+	return repos, nil
+}
+
+func isGitRepo(path string) bool {
+	info, err := os.Stat(filepath.Join(path, ".git"))
+	return err == nil && info.IsDir()
+}
+
+// gitFetch runs a quiet fetch; errors are intentionally ignored (offline is ok).
+func gitFetch(ctx context.Context, dir string) {
+	cmd := exec.CommandContext(ctx, "git", "-C", dir, "fetch", "--quiet", "--no-tags")
+	_ = cmd.Run()
+}
+
+// gitOut runs a git command and returns trimmed stdout, or an error.
+func gitOut(ctx context.Context, dir string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// gitLines runs a git command and returns non-empty output lines.
+func gitLines(ctx context.Context, dir string, args ...string) ([]string, error) {
+	out, err := gitOut(ctx, dir, args...)
+	if err != nil || out == "" {
+		return nil, err
+	}
+	return strings.Split(out, "\n"), nil
+}
+
+// mainBranch returns "main" if it exists on the remote, else "master", else "".
+func mainBranch(ctx context.Context, dir string) string {
+	for _, b := range []string{"main", "master"} {
+		out, err := gitOut(ctx, dir, "rev-parse", "--verify", "origin/"+b)
+		if err == nil && out != "" {
+			return b
+		}
+	}
+	return ""
+}

--- a/internal/watcher/git/watcher.go
+++ b/internal/watcher/git/watcher.go
@@ -385,14 +385,16 @@ func discoverRepos(root string) ([]string, error) {
 }
 
 func isGitRepo(path string) bool {
-	info, err := os.Stat(filepath.Join(path, ".git"))
-	return err == nil && info.IsDir()
+	_, err := os.Stat(filepath.Join(path, ".git"))
+	return err == nil
 }
 
-// gitFetch runs a quiet fetch; errors are intentionally ignored (offline is ok).
+// gitFetch runs a quiet fetch with a 30-second timeout; errors are
+// intentionally ignored (offline / stalled remotes should not block polling).
 func gitFetch(ctx context.Context, dir string) {
-	cmd := exec.CommandContext(ctx, "git", "-C", dir, "fetch", "--quiet", "--no-tags")
-	_ = cmd.Run()
+	fctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	_ = exec.CommandContext(fctx, "git", "-C", dir, "fetch", "--quiet", "--no-tags").Run()
 }
 
 // gitOut runs a git command and returns trimmed stdout, or an error.

--- a/internal/watcher/git/watcher.go
+++ b/internal/watcher/git/watcher.go
@@ -91,6 +91,7 @@ type Config struct {
 type repoState struct {
 	path            string
 	currentBranch   string
+	mainBranch      string // cached at seed time; "main", "master", or ""
 	lastRemoteHead  string // last seen origin/<currentBranch> SHA
 	lastMainHead    string // last seen origin/<main|master> SHA
 	filesWarnIssued bool   // true once we've fired the files-changed warning
@@ -208,9 +209,17 @@ func (w *Watcher) run(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
+			// Poll all repos concurrently so a slow fetch on one repo doesn't
+			// delay inspection of the others.
+			var wg sync.WaitGroup
 			for _, rs := range w.repos {
-				w.poll(ctx, rs)
+				wg.Add(1)
+				go func(rs *repoState) {
+					defer wg.Done()
+					w.poll(ctx, rs)
+				}(rs)
 			}
+			wg.Wait()
 		}
 	}
 }
@@ -226,8 +235,9 @@ func (w *Watcher) fetchAndSeed(ctx context.Context, rs *repoState) {
 	}
 	rs.currentBranch = branch
 	rs.lastRemoteHead, _ = gitOut(ctx, rs.path, "rev-parse", "origin/"+branch)
-	if mb := mainBranch(ctx, rs.path); mb != "" {
-		rs.lastMainHead, _ = gitOut(ctx, rs.path, "rev-parse", "origin/"+mb)
+	rs.mainBranch = mainBranch(ctx, rs.path) // cached; rarely changes
+	if rs.mainBranch != "" {
+		rs.lastMainHead, _ = gitOut(ctx, rs.path, "rev-parse", "origin/"+rs.mainBranch)
 	}
 }
 
@@ -252,8 +262,9 @@ func (w *Watcher) poll(ctx context.Context, rs *repoState) {
 		rs.lastRemoteHead, _ = gitOut(ctx, rs.path, "rev-parse", "origin/"+branch)
 		rs.filesWarnIssued = false
 		rs.ageWarnIssued = false
+	} else {
+		rs.currentBranch = branch
 	}
-	rs.currentBranch = branch
 
 	// ── Remote pushes to the current branch ───────────────────────────────────
 	remoteHead, _ := gitOut(ctx, rs.path, "rev-parse", "origin/"+branch)
@@ -261,7 +272,7 @@ func (w *Watcher) poll(ctx context.Context, rs *repoState) {
 		commits, _ := gitLines(ctx, rs.path, "log",
 			rs.lastRemoteHead+".."+remoteHead, "--oneline", "--no-decorate")
 		w.emit(events.EventMessage,
-			fmt.Sprintf("[%s] %d new commit(s) pushed to %s by someone else",
+			fmt.Sprintf("[%s] %d new commit(s) on %s (remote advanced)",
 				repoLabel, len(commits), branch),
 			map[string]any{
 				"repo":    rs.path,
@@ -275,7 +286,7 @@ func (w *Watcher) poll(ctx context.Context, rs *repoState) {
 	}
 
 	// ── Activity on main/master ───────────────────────────────────────────────
-	mb := mainBranch(ctx, rs.path)
+	mb := rs.mainBranch
 	if mb != "" && branch != mb {
 		mainHead, _ := gitOut(ctx, rs.path, "rev-parse", "origin/"+mb)
 		if mainHead != "" && rs.lastMainHead != "" && mainHead != rs.lastMainHead {
@@ -348,12 +359,15 @@ func (w *Watcher) poll(ctx context.Context, rs *repoState) {
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-// expandPath resolves ~ and cleans the path.
+// expandPath resolves ~ and ~/ prefixes and cleans the path.
 func expandPath(p string) (string, error) {
-	if strings.HasPrefix(p, "~/") {
+	if p == "~" || strings.HasPrefix(p, "~/") {
 		home, err := os.UserHomeDir()
 		if err != nil {
 			return "", err
+		}
+		if p == "~" {
+			return home, nil
 		}
 		p = filepath.Join(home, p[2:])
 	}

--- a/internal/watcher/git/watcher_test.go
+++ b/internal/watcher/git/watcher_test.go
@@ -2,9 +2,11 @@ package git
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -169,6 +171,238 @@ func TestWatcher_MissingPath(t *testing.T) {
 		case <-deadline:
 			t.Fatal("timeout: watcher did not shut down")
 		}
+	}
+}
+
+// ── Poll integration helpers ──────────────────────────────────────────────────
+
+// mustGit runs a git command in dir, fataling the test on error.
+func mustGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v in %s:\n%s", args, dir, out)
+	}
+}
+
+// mustGitEnv is like mustGit but prepends extra environment variables.
+func mustGitEnv(t *testing.T, dir string, env []string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), env...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v in %s:\n%s", args, dir, out)
+	}
+}
+
+// drainEvents reads all buffered events from ch without blocking.
+func drainEvents(ch <-chan events.WatchEvent) []events.WatchEvent {
+	var out []events.WatchEvent
+	for {
+		select {
+		case e := <-ch:
+			out = append(out, e)
+		default:
+			return out
+		}
+	}
+}
+
+// setupPollEnv creates a three-repo topology:
+//
+//	origin - accepts pushes to its checked-out branch (denyCurrentBranch=ignore)
+//	local  - cloned from origin; this is what the test watcher monitors
+//	pusher - cloned from origin; simulates a second developer pushing changes
+func setupPollEnv(t *testing.T) (origin, local, pusher string) {
+	t.Helper()
+	origin, local, pusher = t.TempDir(), t.TempDir(), t.TempDir()
+	configure := func(dir string) {
+		mustGit(t, dir, "config", "user.email", "test@test.com")
+		mustGit(t, dir, "config", "user.name", "Test")
+	}
+	mustGit(t, origin, "init", "-b", "main")
+	configure(origin)
+	mustGit(t, origin, "config", "receive.denyCurrentBranch", "ignore")
+	mustGit(t, origin, "commit", "--allow-empty", "-m", "init")
+	mustGit(t, local, "clone", origin, ".")
+	configure(local)
+	mustGit(t, pusher, "clone", origin, ".")
+	configure(pusher)
+	return
+}
+
+// newSeededWatcher creates a Watcher with a seeded repoState for localPath.
+func newSeededWatcher(t *testing.T, localPath string, cfg Config) (*Watcher, *repoState) {
+	t.Helper()
+	w := &Watcher{
+		name:     "test",
+		cfg:      cfg,
+		eventsCh: make(chan events.WatchEvent, 32),
+		status:   watcher.StatusConnecting,
+	}
+	rs := &repoState{path: localPath}
+	w.fetchAndSeed(context.Background(), rs)
+	return w, rs
+}
+
+// ── Poll integration tests ────────────────────────────────────────────────────
+
+// TestPoll_NewRemoteCommits verifies that a new commit pushed to the current
+// branch by another developer fires an EventMessage.
+func TestPoll_NewRemoteCommits(t *testing.T) {
+	_, local, pusher := setupPollEnv(t)
+	w, rs := newSeededWatcher(t, local, Config{
+		PollIntervalS:      300,
+		AlertFilesChanged:  50,
+		AlertBranchAgeDays: 14,
+	})
+
+	mustGit(t, pusher, "commit", "--allow-empty", "-m", "remote work")
+	mustGit(t, pusher, "push", "origin", "main")
+
+	w.poll(context.Background(), rs)
+
+	evts := drainEvents(w.eventsCh)
+	var found bool
+	for _, e := range evts {
+		if e.Type == events.EventMessage && strings.Contains(e.Summary, "remote advanced") {
+			found = true
+			count, ok := e.Detail["count"].(int)
+			if !ok || count != 1 {
+				t.Fatalf("expected count=1, got %v", e.Detail["count"])
+			}
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("no remote-advance event; got: %v", evts)
+	}
+}
+
+// TestPoll_MainBranchAdvance verifies that new commits on origin/main fire an
+// EventMessage suggesting a rebase when the local repo is on a feature branch.
+func TestPoll_MainBranchAdvance(t *testing.T) {
+	_, local, pusher := setupPollEnv(t)
+	mustGit(t, local, "checkout", "-b", "feature")
+	w, rs := newSeededWatcher(t, local, Config{
+		PollIntervalS:      300,
+		AlertFilesChanged:  50,
+		AlertBranchAgeDays: 14,
+	})
+	if rs.mainBranch != "main" {
+		t.Fatalf("expected mainBranch=main, got %q", rs.mainBranch)
+	}
+
+	mustGit(t, pusher, "commit", "--allow-empty", "-m", "hotfix on main")
+	mustGit(t, pusher, "push", "origin", "main")
+
+	w.poll(context.Background(), rs)
+
+	evts := drainEvents(w.eventsCh)
+	var found bool
+	for _, e := range evts {
+		if e.Type == events.EventMessage && strings.Contains(e.Summary, "consider rebasing") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("no rebase-suggestion event; got: %v", evts)
+	}
+}
+
+// TestPoll_FilesChangedThreshold verifies that an EventError is emitted when
+// the number of files changed in the branch exceeds alert_files_changed.
+func TestPoll_FilesChangedThreshold(t *testing.T) {
+	_, local, _ := setupPollEnv(t)
+	mustGit(t, local, "checkout", "-b", "big-feature")
+
+	for i := 0; i < 6; i++ {
+		p := filepath.Join(local, fmt.Sprintf("file%d.txt", i))
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustGit(t, local, "add", ".")
+	mustGit(t, local, "commit", "-m", "add 6 files")
+
+	// Threshold is 5 — 6 files should trigger the warning.
+	w, rs := newSeededWatcher(t, local, Config{
+		PollIntervalS:      300,
+		AlertFilesChanged:  5,
+		AlertBranchAgeDays: 14,
+	})
+
+	w.poll(context.Background(), rs)
+
+	evts := drainEvents(w.eventsCh)
+	var found bool
+	for _, e := range evts {
+		if e.Type == events.EventError && strings.Contains(e.Summary, "files changed") {
+			found = true
+			n, ok := e.Detail["files_changed"].(int)
+			if !ok || n != 6 {
+				t.Fatalf("expected files_changed=6, got %v", e.Detail["files_changed"])
+			}
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("no files-changed warning; got: %v", evts)
+	}
+}
+
+// TestPoll_BranchAge verifies that an EventError is emitted when the branch
+// is older than alert_branch_age_days.
+func TestPoll_BranchAge(t *testing.T) {
+	origin := t.TempDir()
+	local := t.TempDir()
+
+	// Seed origin with an init commit dated 30 days in the past so it becomes
+	// the merge-base for the feature branch.
+	mustGit(t, origin, "init", "-b", "main")
+	mustGit(t, origin, "config", "user.email", "test@test.com")
+	mustGit(t, origin, "config", "user.name", "Test")
+	mustGit(t, origin, "config", "receive.denyCurrentBranch", "ignore")
+	oldDate := time.Now().AddDate(0, 0, -30).UTC().Format(time.RFC3339)
+	mustGitEnv(t, origin, []string{
+		"GIT_COMMITTER_DATE=" + oldDate,
+		"GIT_AUTHOR_DATE=" + oldDate,
+	}, "commit", "--allow-empty", "-m", "old init")
+
+	mustGit(t, local, "clone", origin, ".")
+	mustGit(t, local, "config", "user.email", "test@test.com")
+	mustGit(t, local, "config", "user.name", "Test")
+
+	// Branch off the old init commit; the merge-base age will be ~30 days.
+	mustGit(t, local, "checkout", "-b", "long-lived")
+	mustGit(t, local, "commit", "--allow-empty", "-m", "work in progress")
+
+	// Threshold is 14 days — 30-day-old branch should warn.
+	w, rs := newSeededWatcher(t, local, Config{
+		PollIntervalS:      300,
+		AlertFilesChanged:  50,
+		AlertBranchAgeDays: 14,
+	})
+
+	w.poll(context.Background(), rs)
+
+	evts := drainEvents(w.eventsCh)
+	var found bool
+	for _, e := range evts {
+		if e.Type == events.EventError && strings.Contains(e.Summary, "days old") {
+			found = true
+			age, ok := e.Detail["age_days"].(int)
+			if !ok || age < 28 || age > 32 {
+				t.Fatalf("expected age ~30 days, got %v", e.Detail["age_days"])
+			}
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("no branch-age warning; got: %v", evts)
 	}
 }
 

--- a/internal/watcher/git/watcher_test.go
+++ b/internal/watcher/git/watcher_test.go
@@ -1,0 +1,215 @@
+package git
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"auphanim/internal/events"
+	"auphanim/internal/watcher"
+)
+
+// initRepo creates a bare-minimum git repo at dir with one empty commit.
+func initRepo(t *testing.T, dir string) {
+	t.Helper()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %s", args, out)
+		}
+	}
+	run("git", "init", "-b", "main")
+	run("git", "config", "user.email", "test@test.com")
+	run("git", "config", "user.name", "Test")
+	run("git", "commit", "--allow-empty", "-m", "init")
+}
+
+func TestDiscoverRepos_SingleRepo(t *testing.T) {
+	dir := t.TempDir()
+	initRepo(t, dir)
+
+	repos, err := discoverRepos(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(repos) != 1 || repos[0] != dir {
+		t.Fatalf("expected [%s], got %v", dir, repos)
+	}
+}
+
+func TestDiscoverRepos_ParentFolder(t *testing.T) {
+	parent := t.TempDir()
+
+	for _, name := range []string{"repo-a", "repo-b"} {
+		sub := filepath.Join(parent, name)
+		if err := os.Mkdir(sub, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		initRepo(t, sub)
+	}
+	// non-repo sibling should be ignored
+	if err := os.Mkdir(filepath.Join(parent, "not-a-repo"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	repos, err := discoverRepos(parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(repos) != 2 {
+		t.Fatalf("expected 2 repos, got %d: %v", len(repos), repos)
+	}
+}
+
+func TestDiscoverRepos_NoRepos(t *testing.T) {
+	dir := t.TempDir()
+	repos, err := discoverRepos(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(repos) != 0 {
+		t.Fatalf("expected no repos, got %v", repos)
+	}
+}
+
+func TestIsGitRepo(t *testing.T) {
+	dir := t.TempDir()
+	if isGitRepo(dir) {
+		t.Fatal("expected false for plain dir")
+	}
+	initRepo(t, dir)
+	if !isGitRepo(dir) {
+		t.Fatal("expected true after git init")
+	}
+}
+
+func TestExpandPath_Tilde(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home dir")
+	}
+	got, err := expandPath("~/foo/bar")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(home, "foo", "bar")
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestExpandPath_Absolute(t *testing.T) {
+	got, err := expandPath("/tmp/some/path")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "/tmp/some/path" {
+		t.Fatalf("unexpected result: %q", got)
+	}
+}
+
+// TestWatcher_MissingPath checks that the watcher shuts down cleanly and
+// emits an error event when the configured path does not exist.
+func TestWatcher_MissingPath(t *testing.T) {
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "does-not-exist")
+
+	w := &Watcher{
+		name: "test",
+		cfg: Config{
+			Path:               missing,
+			PollIntervalS:      300,
+			AlertFilesChanged:  50,
+			AlertBranchAgeDays: 14,
+			MaxEvents:          100,
+		},
+		eventsCh: make(chan events.WatchEvent, 16),
+		status:   watcher.StatusConnecting,
+	}
+
+	ctx := context.Background()
+	if err := w.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Drain until channel is closed; expect at least one error event.
+	deadline := time.After(5 * time.Second)
+	gotError := false
+	for {
+		select {
+		case evt, ok := <-w.Events():
+			if !ok {
+				if !gotError {
+					t.Fatal("channel closed without emitting an error event")
+				}
+				return
+			}
+			if evt.Type == events.EventError {
+				gotError = true
+			}
+		case <-deadline:
+			t.Fatal("timeout: watcher did not shut down")
+		}
+	}
+}
+
+// TestWatcher_StartStop verifies that Start/Stop lifecycle works on a real repo.
+func TestWatcher_StartStop(t *testing.T) {
+	dir := t.TempDir()
+	initRepo(t, dir)
+
+	w := &Watcher{
+		name: "test",
+		cfg: Config{
+			Path:               dir,
+			PollIntervalS:      300, // long enough to never fire during test
+			AlertFilesChanged:  50,
+			AlertBranchAgeDays: 14,
+			MaxEvents:          100,
+		},
+		eventsCh: make(chan events.WatchEvent, 32),
+		status:   watcher.StatusConnecting,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := w.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Expect a startup message.
+	select {
+	case evt, ok := <-w.Events():
+		if !ok {
+			t.Fatal("channel closed before startup event")
+		}
+		if evt.WatcherType != "git" {
+			t.Fatalf("unexpected watcher type %q", evt.WatcherType)
+		}
+		if evt.WatcherName != "test" {
+			t.Fatalf("unexpected watcher name %q", evt.WatcherName)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for startup event")
+	}
+
+	cancel()
+	w.Stop()
+
+	// Drain until channel closes.
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case _, ok := <-w.Events():
+			if !ok {
+				return // success
+			}
+		case <-deadline:
+			t.Fatal("channel not closed after Stop")
+		}
+	}
+}

--- a/internal/watcher/git/watcher_test.go
+++ b/internal/watcher/git/watcher_test.go
@@ -113,6 +113,20 @@ func TestExpandPath_Absolute(t *testing.T) {
 	}
 }
 
+func TestExpandPath_TildeAlone(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home dir")
+	}
+	got, err := expandPath("~")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != home {
+		t.Fatalf("got %q, want %q", got, home)
+	}
+}
+
 // TestWatcher_MissingPath checks that the watcher shuts down cleanly and
 // emits an error event when the configured path does not exist.
 func TestWatcher_MissingPath(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	// Blank imports trigger each watcher package's init(), which registers
 	// the factory with the global registry.
 	_ "auphanim/internal/watcher/filesystem"
+	_ "auphanim/internal/watcher/git"
 	_ "auphanim/internal/watcher/kafka"
 	_ "auphanim/internal/watcher/logfile"
 	_ "auphanim/internal/watcher/postgres"


### PR DESCRIPTION
## Summary

- Adds a new `git` watcher type (`internal/watcher/git/watcher.go`) that polls local git repos via `git fetch` and reports on branch activity
- Auto-discovers repos: point `path` at a single repo or a parent folder and it scans one level deep for `.git` directories
- Registered in `main.go` and added example to `demo/auphanim.json`

## Events emitted

| Event | Trigger |
|---|---|
| Startup | Repos discovered at launch |
| New remote commits on current branch | Someone else pushed while you were working |
| New commits landed on main/master | You may need to rebase |
| Branch switched | Local checkout change detected |
| Files-changed warning (`EventError`) | Branch diff vs main exceeds `alert_files_changed` |
| Branch-age warning (`EventError`) | Branch older than `alert_branch_age_days` days |

## Config

```json
{
  "name": "My Repos",
  "type": "git",
  "path": "~/Projects",
  "poll_interval_s": 60,
  "alert_files_changed": 50,
  "alert_branch_age_days": 14,
  "max_events": 100
}
```

## Test plan

- [x] `go build` passes cleanly
- [x] `go vet ./...` clean
- [x] 8 unit tests covering repo discovery, path expansion, missing-path error handling, and start/stop lifecycle — all pass
- [x] Full test suite passes (`config`, `store`, `api`, `mcp`, `filesystem`, `logfile`, `redis`, `git`)
- [x] MCP smoke test still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)